### PR TITLE
chore: default organization/registry to the ones bldr was built with

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN go list -mod=readonly all >/dev/null
 FROM base AS build
 COPY . .
 ARG VERSION
-RUN GOOS=linux CGO_ENABLED=0 go build  -a -ldflags "-extldflags \"-static\" -s -w -X github.com/talos-systems/bldr/internal/pkg/constants.Version=${VERSION}" -o /bldr .
+ARG USERNAME
+ARG REGISTRY
+RUN GOOS=linux CGO_ENABLED=0 go build  -a -ldflags "-extldflags \"-static\" -s -w -X github.com/talos-systems/bldr/internal/pkg/constants.Version=${VERSION} -X github.com/talos-systems/bldr/internal/pkg/constants.DefaultOrganization=${USERNAME} -X github.com/talos-systems/bldr/internal/pkg/constants.DefaultRegistry=${REGISTRY}" -o /bldr .
 FROM scratch AS bldr
 COPY --from=build /bldr /bldr
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ BUILD := docker buildx build
 COMMON_ARGS := --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --build-arg=VERSION=$(TAG)
+COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
+COMMON_ARGS += --build-arg=REGISTRY=$(REGISTRY)
 
 PKGS := alpine scratch bldr
 

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"github.com/talos-systems/bldr/internal/pkg/constants"
 	"github.com/talos-systems/bldr/internal/pkg/types/v1alpha1"
 )
 
@@ -31,13 +32,12 @@ about a number of things.
 }
 
 func init() {
-	packCmd.Flags().StringVarP(&options.Registry, "registry", "r", "docker.io", "Docker registry to tag the image with")
-	packCmd.Flags().StringVarP(&options.Organization, "organization", "o", "", "Docker organization to tag the image with")
+	packCmd.Flags().StringVarP(&options.Registry, "registry", "r", constants.DefaultRegistry, "Docker registry to tag the image with")
+	packCmd.Flags().StringVarP(&options.Organization, "organization", "o", constants.DefaultOrganization, "Docker organization to tag the image with")
 	packCmd.Flags().StringVarP(&options.Platform, "platform", "", "linux/amd64", "Passed through to docker build command")
 	packCmd.Flags().StringVarP(&options.Progress, "progress", "", "auto", "Passed through to docker build command")
 	packCmd.Flags().StringVarP(&options.Push, "push", "", "false", "Passed through to docker build command")
 	packCmd.Flags().StringVarP(&options.CacheTo, "cache-to", "", "", "Passed through to docker build command")
 	packCmd.Flags().StringVarP(&options.CacheFrom, "cache-from", "", "", "Passed through to docker build command")
-	packCmd.MarkFlagRequired("organization")
 	rootCmd.AddCommand(packCmd)
 }

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -1,5 +1,7 @@
 package constants
 
 var (
-	Version string
+	DefaultRegistry     string
+	DefaultOrganization string
+	Version             string
 )


### PR DESCRIPTION
This allows to use `bldr pack` without `-o` option: official `bldr`
builds will have `autonomy` as default, while for local development,
`$USERNAME` will be used instead (this includes both `bldr` image and
the images built with `bldr`). Default value can be still overridden of
course.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>