### PR TITLE
chore: make bldr push its images on 'master' build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,6 +32,29 @@ steps:
     volumes:
       - name: docker-socket
         path: /var/run
+    when:
+      event:
+        include:
+          - pull_request
+
+  - name: build-and-publish
+    image: autonomy/build-container:latest
+    pull: always
+    environment:
+      DOCKER_USERNAME:
+        from_secret: docker_username
+      DOCKER_PASSWORD:
+        from_secret: docker_password
+    commands:
+      - docker login --username "$${DOCKER_USERNAME}" --password "$${DOCKER_PASSWORD}"
+      - make PLATFORM=linux/amd64 PUSH=true
+    volumes:
+      - name: docker-socket
+        path: /var/run
+    when:
+      event:
+        exclude:
+          - pull_request
 
 volumes:
   - name: docker-socket


### PR DESCRIPTION
There's only one image now (`-frontend`) which is used as buildkit
frontend via shebang and dockerfile.v0.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>