### PR TITLE
feat: graph external dependencies (images) in addition to stages

### DIFF
--- a/internal/pkg/solver/graph.go
+++ b/internal/pkg/solver/graph.go
@@ -24,7 +24,21 @@ func (node *PackageNode) DumpDot(g *dot.Graph) dot.Node {
 	n := g.Node(node.Name)
 
 	for _, dep := range node.DependsOn {
-		n.Edge(dep.DumpDot(g))
+		depNode := dep.DumpDot(g)
+		if len(depNode.EdgesTo(n)) == 0 {
+			depNode.Edge(n)
+		}
+	}
+
+	for _, dep := range node.Pkg.ExternalDependencies() {
+		imageNode := g.Node(dep)
+		imageNode.Box()
+		imageNode.Attr("fillcolor", "lemonchiffon")
+		imageNode.Attr("style", "filled")
+
+		if len(imageNode.EdgesTo(n)) == 0 {
+			imageNode.Edge(n)
+		}
 	}
 
 	return n

--- a/internal/pkg/types/v1alpha2/deps.go
+++ b/internal/pkg/types/v1alpha2/deps.go
@@ -43,3 +43,14 @@ func (deps Dependencies) GetInternal() (internalDeps []string) {
 
 	return
 }
+
+// GetExternal returns list of all the external dependencies (images)
+func (deps Dependencies) GetExternal() (images []string) {
+	for _, dep := range deps {
+		if !dep.IsInternal() {
+			images = append(images, dep.Image)
+		}
+	}
+
+	return
+}

--- a/internal/pkg/types/v1alpha2/pkg.go
+++ b/internal/pkg/types/v1alpha2/pkg.go
@@ -55,3 +55,8 @@ func NewPkg(baseDir string, contents []byte, vars types.Variables) (*Pkg, error)
 func (p *Pkg) InternalDependencies() []string {
 	return p.Dependencies.GetInternal()
 }
+
+// ExternalDependencies returns list of external images
+func (p *Pkg) ExternalDependencies() []string {
+	return p.Dependencies.GetExternal()
+}


### PR DESCRIPTION
Also adds edge de-duplication (some were duplicated when walking
dependency path multiple times).

Next PR will rework `dot` generation to avoid duplicates.

Fixes #21

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>