### PR TITLE
feat: allow 'graph' to be generated without 'target'

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -24,20 +24,30 @@ starting from target to all the dependencies.
 			Root:    pkgRoot,
 			Context: options.GetVariables(),
 		}
+
 		packages, err := solver.NewPackages(&loader)
 		if err != nil {
 			log.Fatal(err)
 		}
-		graph, err := packages.Resolve(options.Target)
-		if err != nil {
-			log.Fatal(err)
+
+		var packageSet solver.PackageSet
+
+		if options.Target != "" {
+			graph, err := packages.Resolve(options.Target)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			packageSet = graph.ToSet()
+		} else {
+			packageSet = packages.ToSet()
 		}
-		graph.DumpDot(os.Stdout)
+
+		packageSet.DumpDot(os.Stdout)
 	},
 }
 
 func init() {
-	graphCmd.Flags().StringVarP(&options.Target, "target", "t", "", "Target image to build")
-	graphCmd.MarkFlagRequired("target") //nolint: errcheck
+	graphCmd.Flags().StringVarP(&options.Target, "target", "t", "", "Target image to graph, if not set - graph all stages")
 	rootCmd.AddCommand(graphCmd)
 }

--- a/internal/pkg/convert/graph.go
+++ b/internal/pkg/convert/graph.go
@@ -25,6 +25,8 @@ type GraphLLB struct {
 	BaseImages   map[v1alpha2.Variant]llb.State
 	Checksummer  llb.State
 	LocalContext llb.State
+
+	cache map[*solver.PackageNode]llb.State
 }
 
 // NewGraphLLB creates new GraphLLB and initializes shared images.
@@ -32,6 +34,7 @@ func NewGraphLLB(graph *solver.PackageGraph, options *environment.Options) *Grap
 	result := &GraphLLB{
 		PackageGraph: graph,
 		Options:      options,
+		cache:        make(map[*solver.PackageNode]llb.State),
 	}
 
 	result.buildBaseImages()

--- a/internal/pkg/convert/node.go
+++ b/internal/pkg/convert/node.go
@@ -6,6 +6,7 @@ package convert
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"sort"
 
@@ -214,6 +215,11 @@ func (node *NodeLLB) finalize(root llb.State) llb.State {
 func (node *NodeLLB) Build() (llb.State, error) {
 	var err error
 
+	if state, ok := node.Graph.cache[node.PackageNode]; ok {
+		log.Printf("cached node %s", node.Name)
+		return state, nil
+	}
+
 	root := node.base()
 	root = node.install(root)
 	root = node.context(root)
@@ -228,6 +234,8 @@ func (node *NodeLLB) Build() (llb.State, error) {
 	}
 
 	root = node.finalize(root)
+
+	node.Graph.cache[node.PackageNode] = root
 
 	return root, nil
 }

--- a/internal/pkg/solver/set.go
+++ b/internal/pkg/solver/set.go
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package solver
+
+import (
+	"io"
+
+	"github.com/emicklei/dot"
+)
+
+// PackageSet is a list of PackageNodes
+type PackageSet []*PackageNode
+
+// DumpDot dumps nodes and deps in dot format
+func (set PackageSet) DumpDot(w io.Writer) {
+	g := dot.NewGraph(dot.Directed)
+
+	for _, node := range set {
+		node.DumpDot(g)
+	}
+
+	g.Write(w)
+}


### PR DESCRIPTION
This switches off dependency resolution mode and dumps all the stages
(targets) as a graph.

While working on this feature, I discovered two cases when parts of the
build graph were duplicated: first when packages were resolved, leading
to duplicate nodes in the graph, second when LLB is generated. Buildkit
seems to handle correctly LLB de-duplication, but anyway it's better to
skip duplicate entries.

Fixes #22

As examples, see talos-systems/tools#73 and talos-systems/pkgs#46

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>