### PR TITLE
feat: add support for runtime dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.13
 
 require (
 	github.com/emicklei/dot v0.10.1
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/moby/buildkit v0.6.2-0.20190921015714-10cef0c6e178
 	github.com/opencontainers/go-digest v1.0.0-rc1
-	github.com/otiai10/copy v1.0.2
 	github.com/spf13/cobra v0.0.4
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7

--- a/go.sum
+++ b/go.sum
@@ -66,7 +66,11 @@ github.com/google/shlex v0.0.0-20150127133951-6f45313302b9 h1:JM174NTeGNJ2m/oLH3
 github.com/google/shlex v0.0.0-20150127133951-6f45313302b9/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -107,12 +111,6 @@ github.com/opencontainers/runc v1.0.0-rc8.0.20190621203724-f4982d86f7fd/go.mod h
 github.com/opencontainers/runtime-spec v0.0.0-20180909173843-eba862dc2470/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20171029140428-b1a47cfbdd75/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v0.0.0-20171003133519-1361b9cd60be/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
-github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
-github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
-github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/pkg/solver/buildkit_loader.go
+++ b/internal/pkg/solver/buildkit_loader.go
@@ -69,6 +69,7 @@ func (bkfl *BuildkitFrontendLoader) Load() ([]*v1alpha2.Pkg, error) {
 		pkg, err := v1alpha2.NewPkg(baseDir, contents, bkfl.Context)
 		if err != nil {
 			log.Printf("skipping %q: %s", baseDir, err)
+			return
 		}
 
 		log.Printf("loaded pkg %q from %q", pkg.Name, baseDir)

--- a/internal/pkg/types/v1alpha2/pkg.go
+++ b/internal/pkg/types/v1alpha2/pkg.go
@@ -48,15 +48,14 @@ func NewPkg(baseDir string, contents []byte, vars types.Variables) (*Pkg, error)
 		return nil, err
 	}
 
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+
 	return p, nil
 }
 
-// InternalDependencies returns list of internal dependencies names
-func (p *Pkg) InternalDependencies() []string {
-	return p.Dependencies.GetInternal()
-}
-
-// ExternalDependencies returns list of external images
-func (p *Pkg) ExternalDependencies() []string {
-	return p.Dependencies.GetExternal()
+// Validate the Pkg
+func (p *Pkg) Validate() error {
+	return p.Dependencies.Validate()
 }


### PR DESCRIPTION
Fixes #30

This adds `runtime: <bool>` flag to all the dependencies. Runtime
dependencies are implicitly in any stages using this stage (including
transitive runtime dependencies). This allows to dry up dependencies as
we list them in `pkg.yaml`.

Dependency code was rewritten while implementing this change, now
internal and external dependencies are handled in the same list.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>