### PR TITLE
feat: implement `Pkgfile` and support variables for templates

### DIFF
--- a/internal/pkg/types/v1alpha2/pkg.go
+++ b/internal/pkg/types/v1alpha2/pkg.go
@@ -8,9 +8,10 @@ import (
 	"bytes"
 	"text/template"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/talos-systems/bldr/internal/pkg/constants"
 	"github.com/talos-systems/bldr/internal/pkg/types"
-	"gopkg.in/yaml.v2"
 )
 
 // Pkg represents build instructions for a single package

--- a/internal/pkg/types/v1alpha2/pkgfile.go
+++ b/internal/pkg/types/v1alpha2/pkgfile.go
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package v1alpha2
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/talos-systems/bldr/internal/pkg/types"
+)
+
+// Pkgfile describes structure of 'Pkgfile'
+type Pkgfile struct {
+	Format string          `yaml:"format"`
+	Vars   types.Variables `yaml:"vars,omitempty"`
+}
+
+// NewPkgfile loads Pkgfile from `[]byte` contents
+func NewPkgfile(contents []byte) (*Pkgfile, error) {
+	var pkgfile Pkgfile
+
+	if err := yaml.Unmarshal(contents, &pkgfile); err != nil {
+		return nil, err
+	}
+
+	// TODO: this might be used in the future to pick correct format
+	//       based on Pkgfile, leave it simple for now
+	if pkgfile.Format != "v1alpha2" {
+		return nil, fmt.Errorf("unsupported format: %q, supported formats: %q", pkgfile.Format, []string{"v1alpha2"})
+	}
+
+	return &pkgfile, nil
+}


### PR DESCRIPTION
And `vars:` declared in the `Pkgfile` are used to template `pkg.yaml`
files. Key `format:` is more for the future format changes, but I left
it simple until the next incompatible upgrade.

Fixes #23

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>