### PR TITLE
chore: remove ca-certificates from base image

### DIFF
--- a/internal/pkg/convert/graph.go
+++ b/internal/pkg/convert/graph.go
@@ -75,7 +75,7 @@ func (graph *GraphLLB) buildBaseImages() {
 		constants.DefaultBaseImage,
 		llb.WithCustomName("base"),
 	).Run(
-		llb.Shlex("apk --no-cache add bash ca-certificates"),
+		llb.Shlex("apk --no-cache --update add bash"),
 		llb.WithCustomName("base-apkinstall"),
 	).Run(
 		llb.Args([]string{"ln", "-svf", "/bin/bash", "/bin/sh"}),
@@ -90,7 +90,7 @@ func (graph *GraphLLB) buildChecksummer() {
 		constants.DefaultBaseImage,
 		llb.WithCustomName("cksum"),
 	).Run(
-		llb.Shlex("apk --no-cache add coreutils"),
+		llb.Shlex("apk --no-cache --update add coreutils"),
 		llb.WithCustomName("cksum-apkinstall"),
 	).Root()
 }


### PR DESCRIPTION
This isn't required anymore as downloads don't happen during the build.
Also adds `--update` to `apk` calls to be on the safe side.

Fixes #31

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>