### PR TITLE
chore: switch version generation to `git describe`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= docker.io
 USERNAME ?= autonomy
-TAG = $(shell gitmeta image tag)
+TAG = $(shell git describe --tags --dirty --always)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 
 PLATFORM ?= linux/amd64


### PR DESCRIPTION
If no tags are present: `8513435-dirty` or `8513435`

Exactly on the tag `v0.1`: `v0.1-dirty` or `v0.1`

Some commits ahead of tag `v0.1`: `v0.1-1-g23cbce5` (1 commit ahead, `g`
followed by abbreviated git SHA).

Pros:

- versions are sortable, later version is '>' than previous one
- version after any tag shows which is the closest release to the tag

Cons:

- you tell me :)

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>