### PR TITLE
feat: stop on error in any package, more validation

### DIFF
--- a/internal/pkg/convert/node.go
+++ b/internal/pkg/convert/node.go
@@ -6,7 +6,6 @@ package convert
 
 import (
 	"fmt"
-	"log"
 	"path/filepath"
 	"sort"
 
@@ -233,7 +232,6 @@ func (node *NodeLLB) Build() (llb.State, error) {
 	var err error
 
 	if state, ok := node.Graph.cache[node.PackageNode]; ok {
-		log.Printf("cached node %s", node.Name)
 		return state, nil
 	}
 

--- a/internal/pkg/pkgfile/build.go
+++ b/internal/pkg/pkgfile/build.go
@@ -80,7 +80,7 @@ func Build(ctx context.Context, c client.Client, options *environment.Options) (
 }
 
 func fetchPkgs(ctx context.Context, c client.Client) (client.Reference, error) {
-	name := fmt.Sprintf("load %s and %ss", constants.Pkgfile, constants.Pkgfile)
+	name := fmt.Sprintf("load %s and %ss", constants.Pkgfile, constants.PkgYaml)
 
 	src := llb.Local(localNameDockerfile,
 		llb.IncludePatterns([]string{

--- a/internal/pkg/solver/filesystem_loader.go
+++ b/internal/pkg/solver/filesystem_loader.go
@@ -46,8 +46,8 @@ func (fspl *FilesystemPackageLoader) walkFunc() filepath.WalkFunc {
 		if info.Name() == constants.PkgYaml {
 			pkg, e := fspl.loadPkg(path)
 			if e != nil {
-				fspl.Logger.Printf("skipping %q: %s", path, e)
-				return nil
+				fspl.Logger.Printf("error loading %q: %s", path, e)
+				return fmt.Errorf("error loading %q: %w", path, e)
 			}
 			fspl.Logger.Printf("loaded pkg %q from %q", pkg.Name, path)
 			fspl.pkgs = append(fspl.pkgs, pkg)

--- a/internal/pkg/types/v1alpha2/source.go
+++ b/internal/pkg/types/v1alpha2/source.go
@@ -4,6 +4,28 @@
 
 package v1alpha2
 
+import (
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// Sources is a collection of Source
+type Sources []Source
+
+// Validate sources
+func (sources Sources) Validate() error {
+	var multiErr *multierror.Error
+
+	for _, source := range sources {
+		multiErr = multierror.Append(multiErr, source.Validate())
+	}
+
+	return multiErr.ErrorOrNil()
+}
+
 // Source describe build source to be downloaded
 type Source struct {
 	URL         string `yaml:"url,omitempty"`
@@ -15,4 +37,29 @@ type Source struct {
 // ToSHA512Sum returns in format of line expected by 'sha512sum'
 func (source *Source) ToSHA512Sum() []byte {
 	return []byte(source.SHA512 + " *" + source.Destination + "\n")
+}
+
+// Validate source
+func (source *Source) Validate() error {
+	var multiErr *multierror.Error
+
+	if source.URL == "" {
+		multiErr = multierror.Append(multiErr, errors.New("source.url can't be empty"))
+	} else if _, err := url.Parse(source.URL); err != nil {
+		multiErr = multierror.Append(multiErr, fmt.Errorf("error parsing source.url %q: %w", source.URL, err))
+	}
+
+	if source.Destination == "" {
+		multiErr = multierror.Append(multiErr, errors.New("source.destination can't be empty"))
+	}
+
+	if source.SHA256 == "" {
+		multiErr = multierror.Append(multiErr, errors.New("source.sha256 can't be empty"))
+	}
+
+	if source.SHA512 == "" {
+		multiErr = multierror.Append(multiErr, errors.New("source.sha512 can't be empty"))
+	}
+
+	return multiErr.ErrorOrNil()
 }

--- a/internal/pkg/types/v1alpha2/steps.go
+++ b/internal/pkg/types/v1alpha2/steps.go
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package v1alpha2
+
+import "github.com/hashicorp/go-multierror"
+
+// Environment is a set of environment variables to be set in the step.
+type Environment map[string]string
+
+// Steps is a collection of Step
+type Steps []Step
+
+// Validate steps
+func (steps Steps) Validate() error {
+	var multiErr *multierror.Error
+
+	for _, step := range steps {
+		multiErr = multierror.Append(multiErr, step.Validate())
+	}
+
+	return multiErr.ErrorOrNil()
+}
+
+// Step describes a single build step.
+//
+// Steps are executed sequentially, each step runs in its own
+// empty temporary directory.
+type Step struct {
+	Sources Sources      `yaml:"sources,omitempty"`
+	Env     Environment  `yaml:"env,omitempty"`
+	Prepare Instructions `yaml:"prepare,omitempty"`
+	Build   Instructions `yaml:"build,omitempty"`
+	Install Instructions `yaml:"install,omitempty"`
+	Test    Instructions `yaml:"test,omitempty"`
+
+	TmpDir string `yaml:"-"`
+}
+
+// Validate the step
+func (step *Step) Validate() error {
+	return step.Sources.Validate()
+}

--- a/internal/pkg/types/v1alpha2/types.go
+++ b/internal/pkg/types/v1alpha2/types.go
@@ -7,24 +7,6 @@ package v1alpha2
 // Install is a list of Alpine package names to install.
 type Install []string
 
-// Environment is a set of environment variables to be set in the step.
-type Environment map[string]string
-
-// Step describes a single build step.
-//
-// Steps are executed sequentially, each step runs in its own
-// empty temporary directory.
-type Step struct {
-	Sources []Source     `yaml:"sources,omitempty"`
-	Env     Environment  `yaml:"env,omitempty"`
-	Prepare Instructions `yaml:"prepare,omitempty"`
-	Build   Instructions `yaml:"build,omitempty"`
-	Install Instructions `yaml:"install,omitempty"`
-	Test    Instructions `yaml:"test,omitempty"`
-
-	TmpDir string `yaml:"-"`
-}
-
 // Finalize is a set of COPY instructions to finalize the build.
 type Finalize struct {
 	From string `yaml:"from,omitempty"`


### PR DESCRIPTION
Pack of small fixes to `bldr` discovered while working on the
tests.

When loading package fails, it gets logged, but when using frontend mode
this log is hard to reach: it goes into buildkitd docker container log.
Skipped package would probably result in some dependency not being
resolvable, and actual error would be buried deep in the log.

Instead of that, abort processing and return an error which is printed
to console log when processing dockerfile frontend.

Do more validation for `pkg.yaml` as invalid field values lead to
cryptic LLB errors which are hard to match with `pkg.yaml` problems.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>