### PR TITLE
feat: add `bldr validate` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ Most common output type is pushing to the registry:
 
 Graph of dependencies could be generated via `bldr` CLI:
 
-  bldr graph
+```shell
+bldr graph
+```
 
 This command also accepts `--target` flag to graph only part of the tree
 leading to the target:
@@ -89,6 +91,15 @@ This renders graph like:
 Boxes with yellow background are external images as dependencies, white
 nodes are internal stages. Arrows present dependencies: regular arrows
 for build dependencies and green bold arrows for runtime dependencies.
+
+### Validating pkg.yaml files
+
+`bldr` always validates `pkg.yaml` files while loading them and fails the build on errors.
+Validation step could also be executed separately as the first step before running actual build:
+
+```shell
+bldr validate
+```
 
 ## Format
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/talos-systems/bldr/internal/pkg/solver"
+)
+
+// validateCmd represents the graph command
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate syntax of pkg.yaml files",
+	Long: `This command scans directory tree for pkg.yaml files,
+loads them and validates for errors. `,
+	Run: func(cmd *cobra.Command, args []string) {
+		loader := solver.FilesystemPackageLoader{
+			Root:    pkgRoot,
+			Context: options.GetVariables(),
+		}
+
+		_, err := solver.NewPackages(&loader)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}


### PR DESCRIPTION
This command might be nice as a first step in CI flow to validate
structure before actually trying to build it.

This also changes loader to scan whole tree and report all the
validation errors.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>