### PR TITLE
feat: implement integration tests for bldr

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,9 +9,8 @@ services:
     entrypoint:
     - dockerd
     command:
-      - --dns=8.8.8.8
-      - --dns=8.8.4.4
       - --mtu=1440
+      - --insecure-registry=registry.ci.svc:5000
     volumes:
       - name: docker-socket
         path: /var/run
@@ -24,12 +23,18 @@ steps:
     when:
       event: tag
 
-  - name: build
+  - name: build-and-test
     image: autonomy/build-container:latest
     pull: always
+    environment:
+      REGISTRY: registry.ci.svc:5000
+      PLATFORM: linux/amd64
+      BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
     commands:
-      - docker buildx create --driver docker-container --platform linux/amd64 --name local --use
-      - make PLATFORM=linux/amd64 PUSH=false
+      - docker buildx create --driver docker-container --platform linux/amd64 --name local --config hack/buildkit.conf --use
+      - make # build everything
+      - make frontend PUSH=true  # push only frontend for integration tests
+      - make integration
     volumes:
       - name: docker-socket
         path: /var/run
@@ -38,10 +43,12 @@ steps:
         include:
           - pull_request
 
-  - name: build-and-publish
+  - name: build-and-test-and-publish
     image: autonomy/build-container:latest
     pull: always
     environment:
+      PLATFORM: linux/amd64
+      BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
       DOCKER_USERNAME:
         from_secret: docker_username
       DOCKER_PASSWORD:
@@ -49,7 +56,8 @@ steps:
     commands:
       - docker buildx create --driver docker-container --platform linux/amd64 --name local --use
       - docker login --username "$${DOCKER_USERNAME}" --password "$${DOCKER_PASSWORD}"
-      - make PLATFORM=linux/amd64 PUSH=true
+      - make PUSH=true
+      - make integration
     volumes:
       - name: docker-socket
         path: /var/run

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,15 @@ bldr:
 	-f ./Dockerfile \
 	.
 
+.PHONY: integration.test
+integration.test:
+	mkdir -p out
+	$(BUILD) $(COMMON_ARGS) \
+	--target=$@ \
+	--output=type=local,dest=./out \
+	-f ./Dockerfile \
+	.
+
 .PHONY: lint
 lint:
 	$(BUILD) $(COMMON_ARGS) \
@@ -36,10 +45,13 @@ lint:
 
 .PHONY: frontend
 frontend:
-
 	$(BUILD) $(COMMON_ARGS) \
 	--push=$(PUSH) \
 	--target=$@ \
 	--tag $(REGISTRY_AND_USERNAME)/bldr:$(TAG)-$@ \
 	-f ./Dockerfile \
 	.
+
+.PHONY: integration
+integration: integration.test bldr
+	cd internal/pkg/integration && PATH="$$PWD/../../../out:$$PATH"  integration.test -test.v

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Due to the way LLB is executed, some steps might be executed out of order if the
 When developing `bldr`, going via `dockerfile` frontend mode is not always the best way as it requires pushing frontend image each time any change is done. To help with development flow, `bldr` CLI supports `llb` command which emits LLB directly which can be piped into `buildctl`:
 
 ```shell
-bldr llb --root . --target tools | buildctl ...
+bldr llb --root . --target tools | buildctl build --local context=.
 ```
 
 LLB generated in this mode is equivalent to the LLB generated via dockerfile frontend.

--- a/cmd/frontend.go
+++ b/cmd/frontend.go
@@ -20,6 +20,14 @@ var frontendCmd = &cobra.Command{
 	Use:   "frontend",
 	Short: "Buildkit frontend for Pkgfile",
 	Long: `This command implements buildkit frontend.
+
+To activate, put following line as the first line of Pkgfile:
+
+# syntax = docker.io/autonomy/bldr:<version>-frontend
+
+Run with:
+
+  docker buildx build -f ./Pkgfile --target <target> .
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := grpcclient.RunFromEnvironment(

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -18,6 +18,10 @@ var graphCmd = &cobra.Command{
 	Short: "Graph dependencies between pkgs",
 	Long: `This command outputs 'dot' formatted DAG of dependencies
 starting from target to all the dependencies.
+
+Typical usage:
+
+  bldr graph | dot -Tpng > graph.png
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		loader := solver.FilesystemPackageLoader{

--- a/cmd/llb.go
+++ b/cmd/llb.go
@@ -21,23 +21,6 @@ var llbCmd = &cobra.Command{
 	Short: "Dump buildkit LLB for the build",
 	Long: `This command parses build instructions from pkg.yaml files,
 and outputs buildkit LLB to stdout. This can be used as 'bldr pack ... | buildctl ...'.
-
-A pkg.yaml can contain any number of steps that will be executed in order.
-A set of evnironment variables are available in each step:
-
-- ARCH: The architecture of the current machine.
-- BUILD: The target triple for the build machine.
-- HOST: The target triple for the intended machine where the resulting binaries will be executed.
-- TARGET: The target triple that the compiler will produce code for.
-- VENDOR: An arbitrary string used to identify the vendor of the toolchain.
-- SYSROOT:
-- CFLAGS: A preset set of flags to optimize builds.
-- CXXFLAGS: A preset set of flags to optimize builds.
-- LDFLAGS: A preset set of flags to optimize builds.
-
-The general format of a target triple is:
-	<arch><sub>-<vendor>-<sys>-<abi>
-See https://gcc.gnu.org/onlinedocs/gccint/Configure-Terms.html for a detailed description of target triples.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		loader := solver.FilesystemPackageLoader{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ exposed as a CLI tool. In that mode of operation bldr loads root Pkgfile and
 a set of pkg.yamls, processes them, builds dependency graph and outputs it
 as LLB graph to buildkit backend.
 
-bldr can be also used to procude graph of dependencies between build steps and
+bldr can be also used to produce graph of dependencies between build steps and
 output LLB directly which is useful for development or debugging.`,
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/talos-systems/bldr
 go 1.13
 
 require (
+	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053
 	github.com/emicklei/dot v0.10.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/moby/buildkit v0.6.2-0.20190921015714-10cef0c6e178
 	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/otiai10/copy v1.0.2
 	github.com/spf13/cobra v0.0.4
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/hcsshim v0.8.5/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
+github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 h1:H/GMMKYPkEIC3DF/JWQz8Pdd+Feifov2EIgGfNpeogI=
+github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053/go.mod h1:xW8sBma2LE3QxFSzCnH9qe6gAE2yO9GvQaWwX89HxbE=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -111,6 +113,12 @@ github.com/opencontainers/runc v1.0.0-rc8.0.20190621203724-f4982d86f7fd/go.mod h
 github.com/opencontainers/runtime-spec v0.0.0-20180909173843-eba862dc2470/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20171029140428-b1a47cfbdd75/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v0.0.0-20171003133519-1361b9cd60be/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
+github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/hack/buildkit.conf
+++ b/hack/buildkit.conf
@@ -1,0 +1,2 @@
+[registry."registry.ci.svc:5000"]
+http=true

--- a/internal/pkg/integration/integration_test.go
+++ b/internal/pkg/integration/integration_test.go
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/talos-systems/bldr/internal/pkg/util/testutil"
+)
+
+func TestIntegration(t *testing.T) {
+	collection, err := testutil.CollectTests()
+	if err != nil {
+		t.Fatalf("error collecting tests: %v", err)
+	}
+
+	collection.Each(func(name string, f func(*testing.T)) {
+		t.Run(name, f)
+	})
+}

--- a/internal/pkg/integration/testdata/simple/Pkgfile
+++ b/internal/pkg/integration/testdata/simple/Pkgfile
@@ -1,0 +1,3 @@
+# syntax = SHEBANG
+
+format: v1alpha2

--- a/internal/pkg/integration/testdata/simple/go/pkg.yaml
+++ b/internal/pkg/integration/testdata/simple/go/pkg.yaml
@@ -1,0 +1,22 @@
+name: go
+steps:
+- sources:
+  - url: https://dl.google.com/go/go1.12.5.src.tar.gz
+    destination: go1.12.5.src.tar.gz
+    sha256: 2aa5f088cbb332e73fc3def546800616b38d3bfe6b8713b8a6404060f22503e8
+    sha512: ce64105ff71615f9d235cc7c8656b6409fc40cc90d15a28d355fadd9072d2eab842af379dd8bba0f1181715753143e4a07491e0f9e5f8df806327d7c95a34fae
+
+  prepare:
+    -  echo prepare
+
+  build:
+    - echo build
+
+  # test:
+
+  install:
+    -  echo install
+
+finalize:
+  - from: /pkg
+    to: /

--- a/internal/pkg/integration/testdata/simple/test.yaml
+++ b/internal/pkg/integration/testdata/simple/test.yaml
@@ -1,0 +1,17 @@
+---
+run:
+  - name: docker
+    runner: docker
+    target: go
+    expect: success
+  - name: buildkit
+    runner: buildkit
+    target: go
+    expect: success
+  - name: llb
+    runner: llb
+    target: go
+    expect: success
+  - name: validate
+    runner: validate
+    expect: success

--- a/internal/pkg/integration/testdata/stages/Pkgfile
+++ b/internal/pkg/integration/testdata/stages/Pkgfile
@@ -1,0 +1,3 @@
+# syntax = SHEBANG
+
+format: v1alpha2

--- a/internal/pkg/integration/testdata/stages/final/pkg.yaml
+++ b/internal/pkg/integration/testdata/stages/final/pkg.yaml
@@ -1,0 +1,14 @@
+name: final
+dependencies:
+- stage: stage-a
+- stage: stage-b
+- stage: stage-d
+steps:
+- test:
+    - test -f /stage-a/a
+    - test -f /stage-b/b
+    - test -f /stage-d/c
+    - test -f /stage-d/d
+finalize:
+  - from: /
+    to: /

--- a/internal/pkg/integration/testdata/stages/stage-a/pkg.yaml
+++ b/internal/pkg/integration/testdata/stages/stage-a/pkg.yaml
@@ -1,0 +1,11 @@
+name: stage-a
+steps:
+- prepare:
+    - mkdir -p /root
+
+  build:
+    - touch /root/a
+
+finalize:
+  - from: /root
+    to: /stage-a

--- a/internal/pkg/integration/testdata/stages/stage-b/pkg.yaml
+++ b/internal/pkg/integration/testdata/stages/stage-b/pkg.yaml
@@ -1,0 +1,11 @@
+name: stage-b
+steps:
+- prepare:
+    - mkdir -p /root
+
+  build:
+    - touch /root/b
+
+finalize:
+  - from: /root
+    to: /stage-b

--- a/internal/pkg/integration/testdata/stages/stage-d/stage-c/pkg.yaml
+++ b/internal/pkg/integration/testdata/stages/stage-d/stage-c/pkg.yaml
@@ -1,0 +1,11 @@
+name: stage-c
+steps:
+- prepare:
+    - mkdir -p /root
+
+  build:
+    - cp /pkg/c /root
+
+finalize:
+  - from: /root
+    to: /stage-c

--- a/internal/pkg/integration/testdata/stages/stage-d/stage-d/pkg.yaml
+++ b/internal/pkg/integration/testdata/stages/stage-d/stage-d/pkg.yaml
@@ -1,0 +1,15 @@
+name: stage-d
+dependencies:
+- stage: stage-c
+steps:
+- prepare:
+    - mkdir -p /root
+
+  build:
+    - touch /root/d
+
+finalize:
+  - from: /root
+    to: /stage-d
+  - from: /stage-c
+    to: /stage-d

--- a/internal/pkg/integration/testdata/stages/test.yaml
+++ b/internal/pkg/integration/testdata/stages/test.yaml
@@ -1,0 +1,17 @@
+---
+run:
+  - name: docker
+    runner: docker
+    target: final
+    expect: success
+  - name: buildkit
+    runner: buildkit
+    target: final
+    expect: success
+  - name: llb
+    runner: llb
+    target: final
+    expect: success
+  - name: validate
+    runner: validate
+    expect: success

--- a/internal/pkg/types/v1alpha2/pkg.go
+++ b/internal/pkg/types/v1alpha2/pkg.go
@@ -66,6 +66,10 @@ func (p *Pkg) Validate() error {
 		multiErr = multierror.Append(multiErr, errors.New("package name can't be empty"))
 	}
 
+	if len(p.Finalize) == 0 {
+		multiErr = multierror.Append(multiErr, errors.New("finalize steps are missing, this is going to lead to empty build"))
+	}
+
 	multiErr = multierror.Append(multiErr, p.Steps.Validate(), p.Dependencies.Validate())
 
 	return multiErr.ErrorOrNil()

--- a/internal/pkg/util/testutil/buildkit.go
+++ b/internal/pkg/util/testutil/buildkit.go
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+)
+
+// BuildkitRunner runs bldr via buildctl/buildkit
+type BuildkitRunner struct {
+	CommandRunner
+	Target string
+}
+
+// Run implements Run interface
+func (runner BuildkitRunner) Run(t *testing.T) {
+	if err := IsBuildkitAvailable(); err != nil {
+		t.Skipf("buildkit is not available: %q", err)
+	}
+
+	cmd := exec.Command("buildctl",
+		append(getBuildkitGlobalFlags(),
+			"build",
+			"--frontend", "dockerfile.v0",
+			"--local", "context=.",
+			"--local", "dockerfile=.",
+			"--opt", "filename=Pkgfile",
+			"--opt", "target="+runner.Target,
+		)...,
+	)
+
+	runner.run(t, cmd, "buildkit")
+}
+
+func getBuildkitGlobalFlags() []string {
+	var globalOpts []string
+
+	if buildkitHost, ok := os.LookupEnv("BUILDKIT_HOST"); ok {
+		globalOpts = append(globalOpts, "--addr", buildkitHost)
+	}
+
+	return globalOpts
+}
+
+var (
+	buildkitCheckOnce  sync.Once
+	buildkitCheckError error
+)
+
+// IsBuildkitAvailable returns nil if buildkit is ready to use
+func IsBuildkitAvailable() error {
+	buildkitCheckOnce.Do(func() {
+		buildkitCheckError = exec.Command("buildctl", append(getBuildkitGlobalFlags(), "debug", "workers")...).Run()
+	})
+
+	return buildkitCheckError
+}

--- a/internal/pkg/util/testutil/collection.go
+++ b/internal/pkg/util/testutil/collection.go
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package testutil
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestCollection is a set of integration tests
+type TestCollection struct {
+	Tests []IntegrationTest
+}
+
+// CollectTests builds TestCollection from directory structure.
+func CollectTests() (*TestCollection, error) {
+	collection := TestCollection{}
+
+	paths, err := filepath.Glob("./testdata/*/test.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, manifestPath := range paths {
+		manifest, err := NewTestManifest(manifestPath)
+		if err != nil {
+			return nil, err
+		}
+
+		path := filepath.Dir(manifestPath)
+
+		collection.Tests = append(collection.Tests, IntegrationTest{
+			Name:     filepath.Base(path),
+			Path:     path,
+			Manifest: manifest,
+		})
+	}
+
+	return &collection, nil
+}
+
+// Each iterates over collection providing runner for each test.
+func (collection *TestCollection) Each(f func(string, func(t *testing.T))) {
+	for _, test := range collection.Tests {
+		f(test.Name, test.Run)
+	}
+}

--- a/internal/pkg/util/testutil/docker.go
+++ b/internal/pkg/util/testutil/docker.go
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package testutil
+
+import (
+	"os/exec"
+	"sync"
+	"testing"
+)
+
+// DockerRunner runs bldr via docker buildx
+type DockerRunner struct {
+	CommandRunner
+	Target string
+}
+
+// Run implements Run interface
+func (runner DockerRunner) Run(t *testing.T) {
+	if err := IsDockerAvailable(); err != nil {
+		t.Skipf("docker buildx is not available: %q", err)
+	}
+
+	cmd := exec.Command("docker", "buildx", "build", "-f", "./Pkgfile", "--target", runner.Target, ".")
+
+	runner.run(t, cmd, "docker buildx")
+}
+
+var (
+	dockerCheckOnce  sync.Once
+	dockerCheckError error
+)
+
+// IsDockerAvailable returns nil if docker buildx is ready to use
+func IsDockerAvailable() error {
+	dockerCheckOnce.Do(func() {
+		dockerCheckError = exec.Command("docker", "buildx", "ls").Run()
+	})
+
+	return dockerCheckError
+}

--- a/internal/pkg/util/testutil/integration.go
+++ b/internal/pkg/util/testutil/integration.go
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/otiai10/copy"
+	"github.com/talos-systems/bldr/internal/pkg/constants"
+)
+
+// IntegrationTest describes single integration set (common testdata).
+type IntegrationTest struct {
+	Name     string
+	Path     string
+	Manifest TestManifest
+}
+
+// Run executes integration test.
+func (test IntegrationTest) Run(t *testing.T) {
+	// copy test data to temp directory
+	tempDir, err := ioutil.TempDir("", "bldrtest")
+	if err != nil {
+		t.Fatalf("error creating temp directory: %v", err)
+	}
+
+	defer func() {
+		if err = os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("error cleaning up temp directory: %v", err)
+		}
+	}()
+
+	if err = copy.Copy(test.Path, tempDir); err != nil {
+		t.Fatalf("error copying to temp directory: %v", err)
+	}
+
+	var oldWd string
+
+	oldWd, err = os.Getwd()
+	if err != nil {
+		t.Fatalf("error getting current directory: %v", err)
+	}
+
+	err = os.Chdir(tempDir)
+	if err != nil {
+		t.Fatalf("error changing working directory: %v", err)
+	}
+
+	defer func() {
+		err = os.Chdir(oldWd)
+		if err != nil {
+			t.Fatalf("error restoring working directory: %v", err)
+		}
+	}()
+
+	test.run(t)
+}
+
+func (test IntegrationTest) patch(t *testing.T) {
+	pkgfile, err := os.OpenFile(constants.Pkgfile, os.O_RDWR, os.ModePerm)
+	if err != nil {
+		t.Fatalf("error opening %q: %v", constants.Pkgfile, err)
+	}
+
+	contents, err := ioutil.ReadAll(pkgfile)
+	if err != nil {
+		t.Fatalf("error reading %q: %v", constants.Pkgfile, err)
+	}
+
+	contents = bytes.ReplaceAll(contents, []byte("SHEBANG"), []byte(fmt.Sprintf("%s/%s/bldr:%s-frontend", constants.DefaultRegistry, constants.DefaultOrganization, constants.Version)))
+
+	_, err = pkgfile.Seek(0, io.SeekStart)
+	if err != nil {
+		t.Fatalf("error seeking %q: %v", constants.Pkgfile, err)
+	}
+
+	err = pkgfile.Truncate(0)
+	if err != nil {
+		t.Fatalf("error truncating %q: %v", constants.Pkgfile, err)
+	}
+
+	_, err = pkgfile.Write(contents)
+	if err != nil {
+		t.Fatalf("error writing %q: %v", constants.Pkgfile, err)
+	}
+
+	if err = pkgfile.Close(); err != nil {
+		t.Fatalf("error closing %q: %v", constants.Pkgfile, err)
+	}
+}
+
+func (test IntegrationTest) run(t *testing.T) {
+	test.patch(t)
+
+	for _, runManifest := range test.Manifest.Runs {
+		runner, err := getRunner(runManifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Run(runManifest.Name, runner.Run)
+	}
+}

--- a/internal/pkg/util/testutil/llb.go
+++ b/internal/pkg/util/testutil/llb.go
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package testutil
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/alessio/shellescape"
+)
+
+// LLBRunner runs bldr via bldr llb | buildctl
+type LLBRunner struct {
+	CommandRunner
+	Target string
+}
+
+// Run implements Run interface
+func (runner LLBRunner) Run(t *testing.T) {
+	if err := IsBuildkitAvailable(); err != nil {
+		t.Skipf("buildkit is not available: %q", err)
+	}
+
+	args := getBuildkitGlobalFlags()
+	for i := range args {
+		args[i] = shellescape.Quote(args[i])
+	}
+
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("bldr llb --target=%s | buildctl %s build --local context=.", shellescape.Quote(runner.Target), strings.Join(args, " ")),
+	)
+
+	runner.run(t, cmd, "bldr llb")
+}

--- a/internal/pkg/util/testutil/manifest.go
+++ b/internal/pkg/util/testutil/manifest.go
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package testutil
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// TestManifest describes single integration test in test.ymal.
+type TestManifest struct {
+	Runs []RunManifest `yaml:"run"`
+}
+
+// RunManifest describes single run of integration test.
+type RunManifest struct {
+	Name   string `yaml:"name"`
+	Runner string `yaml:"runner"`
+	Target string `yaml:"target"`
+	Expect string `yaml:"expect"`
+}
+
+// NewTestManifest loads TestManifest from test.yaml file.
+func NewTestManifest(path string) (manifest TestManifest, err error) {
+	var f *os.File
+
+	f, err = os.Open(path)
+	if err != nil {
+		return
+	}
+
+	defer f.Close() //nolint: errcheck
+
+	err = yaml.NewDecoder(f).Decode(&manifest)
+
+	return
+}

--- a/internal/pkg/util/testutil/runners.go
+++ b/internal/pkg/util/testutil/runners.go
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// Run the integration test
+type Run interface {
+	Run(t *testing.T)
+}
+
+// CommandRunner is an abstract runner mix-in which processes command result.
+type CommandRunner struct {
+	Expect string
+}
+
+func (runner CommandRunner) run(t *testing.T, cmd *exec.Cmd, title string) {
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
+	err := cmd.Run()
+
+	switch runner.Expect {
+	case "success":
+		if err != nil {
+			t.Fatalf("%s failed: %v", title, err)
+		}
+	case "fail":
+		if err != nil {
+			t.Fatalf("%s should have failed, but succeeded", title)
+		}
+	default:
+		t.Fatalf("unsupported expect %q", runner.Expect)
+	}
+}
+
+func getRunner(manifest RunManifest) (Run, error) {
+	switch manifest.Runner {
+	case "docker":
+		return DockerRunner{
+			CommandRunner: CommandRunner{
+				Expect: manifest.Expect,
+			},
+			Target: manifest.Target,
+		}, nil
+	case "buildkit":
+		return BuildkitRunner{
+			CommandRunner: CommandRunner{
+				Expect: manifest.Expect,
+			},
+			Target: manifest.Target,
+		}, nil
+	case "llb":
+		return LLBRunner{
+			CommandRunner: CommandRunner{
+				Expect: manifest.Expect,
+			},
+			Target: manifest.Target,
+		}, nil
+	case "validate":
+		return ValidateRunner{
+			CommandRunner: CommandRunner{
+				Expect: manifest.Expect,
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported runner: %q", manifest.Runner)
+	}
+}

--- a/internal/pkg/util/testutil/testutil.go
+++ b/internal/pkg/util/testutil/testutil.go
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Package testutil is a collection of supporting code to run bldr integration tests.
+package testutil

--- a/internal/pkg/util/testutil/validate.go
+++ b/internal/pkg/util/testutil/validate.go
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package testutil
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// ValidateRunner runs bldr validate
+type ValidateRunner struct {
+	CommandRunner
+}
+
+// Run implements Run interface
+func (runner ValidateRunner) Run(t *testing.T) {
+	cmd := exec.Command("bldr", "validate")
+
+	runner.run(t, cmd, "bldr validate")
+}


### PR DESCRIPTION
This is the very start of the work: the framework to run the actual
tests and the very first simple test.

I plan to add: `buildctl llb` runner, "gold" type output assertion, test
for `bldr graph`, `bldr validate`, "gold" type matching for LLB,
negative tests  (checksum mismatch), dependency handling, etc.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>