### PR TITLE
fix: linter shouldn't complain on `finalize` if `steps` are missing

### DIFF
--- a/internal/pkg/types/v1alpha2/pkg.go
+++ b/internal/pkg/types/v1alpha2/pkg.go
@@ -70,7 +70,7 @@ func (p *Pkg) Validate() error {
 		multiErr = multierror.Append(multiErr, errors.New("package name can't be empty"))
 	}
 
-	if len(p.Finalize) == 0 {
+	if len(p.Steps) > 0 && len(p.Finalize) == 0 {
 		multiErr = multierror.Append(multiErr, errors.New("finalize steps are missing, this is going to lead to empty build"))
 	}
 


### PR DESCRIPTION
This was discovered with `tools`/`base`, as it only introduces common
runtime dependencies while not doing any build steps, so missing
`finalize` is harmless.

https://github.com/talos-systems/tools/blob/master/base/pkg.yaml

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>