### PR TITLE
chore: do not run `sha512sum` in shell

### DIFF
--- a/internal/pkg/convert/graph.go
+++ b/internal/pkg/convert/graph.go
@@ -23,7 +23,6 @@ type GraphLLB struct {
 	Options *environment.Options
 
 	BaseImages   map[v1alpha2.Variant]llb.State
-	Checksummer  llb.State
 	LocalContext llb.State
 
 	cache map[*solver.PackageNode]llb.State
@@ -38,7 +37,6 @@ func NewGraphLLB(graph *solver.PackageGraph, options *environment.Options) *Grap
 	}
 
 	result.buildBaseImages()
-	result.buildChecksummer()
 	result.buildLocalContext()
 
 	return result
@@ -83,16 +81,6 @@ func (graph *GraphLLB) buildBaseImages() {
 	).Root()))
 
 	graph.BaseImages[v1alpha2.Scratch] = addEnv(addPkg(llb.Scratch()))
-}
-
-func (graph *GraphLLB) buildChecksummer() {
-	graph.Checksummer = llb.Image(
-		constants.DefaultBaseImage,
-		llb.WithCustomName(graph.Options.CommonPrefix+"cksum"),
-	).Run(
-		llb.Shlex("apk --no-cache --update add coreutils"),
-		llb.WithCustomName(graph.Options.CommonPrefix+"cksum-apkinstall"),
-	).Root()
 }
 
 func (graph *GraphLLB) buildLocalContext() {

--- a/internal/pkg/types/v1alpha2/source.go
+++ b/internal/pkg/types/v1alpha2/source.go
@@ -34,11 +34,6 @@ type Source struct {
 	SHA512      string `yaml:"sha512,omitempty"`
 }
 
-// ToSHA512Sum returns in format of line expected by 'sha512sum'.
-func (source *Source) ToSHA512Sum() []byte {
-	return []byte(source.SHA512 + " *" + source.Destination + "\n")
-}
-
 // Validate source.
 func (source *Source) Validate() error {
 	var multiErr *multierror.Error


### PR DESCRIPTION
That's a bit more faster and easier.

Signed-off-by: Alexey Palazhchenko <alexey.palazhchenko@gmail.com>