### PR TITLE
feat: bump Alpine image for the `alpine` image

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ On the root level, following properties are available:
 - `name` (*str*, *required*): name of the package, also used to reference this package from other packages as dependency.
 
 - `variant` (*str*, *optional*): variant of the base image of the build. Two variants are available:
-  - `alpine`: Alpine Linux 3.10 image with `bash` package pre-installed
+  - `alpine`: Alpine Linux 3.14 image with `bash` package pre-installed
   - `scratch`: scratch (empty) image
   Default variant is `alpine`.
 - `install`: (*list*, *optional*): list of Alpine packages to be installed as part of the build. These packages are usually build dependencies.

--- a/internal/pkg/constants/build.go
+++ b/internal/pkg/constants/build.go
@@ -7,7 +7,7 @@ package constants
 import "os"
 
 // DefaultBaseImage for non-scratch builds.
-const DefaultBaseImage = "docker.io/alpine:3.11"
+const DefaultBaseImage = "docker.io/alpine:3.14"
 
 // DefaultDirMode is UNIX file mode for mkdir.
 const DefaultDirMode os.FileMode = 0755


### PR DESCRIPTION
Use the latest version 3.14.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>