### PR TITLE
feat: implement `SOURCE_DATE_EPOCH` build argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Step `finalize` performs final copying of the build artifacts into scratch image
 
 Finalize instruction `{"from": "/", "to": "/"}` copies full build contents as output image, but usually it doesn't make sense to include build temporary files and build dependencies into the package output. Usual trick to install build result under designated initially empty prefix (e.g. `/rootfs`) and set only contents of that prefix as build output.
 
+If `SOURCE_DATE_EPOCH` build argument is set, `bldr` will update timestamps of all files copied in the `finalize` step to the value of `SOURCE_DATE_EPOCH`.
+
 ### Built-in variables
 
 Variables are made available to the templating engine when processing `pkg.yaml` contents and also pushed into the build as environment variables.

--- a/internal/pkg/environment/options.go
+++ b/internal/pkg/environment/options.go
@@ -5,6 +5,8 @@
 package environment
 
 import (
+	"time"
+
 	"github.com/moby/buildkit/client/llb"
 
 	"github.com/talos-systems/bldr/internal/pkg/types"
@@ -12,11 +14,12 @@ import (
 
 // Options for bldr.
 type Options struct {
-	BuildPlatform  Platform
-	TargetPlatform Platform
-	Target         string
-	CommonPrefix   string
-	ProxyEnv       *llb.ProxyEnv
+	BuildPlatform   Platform
+	TargetPlatform  Platform
+	Target          string
+	CommonPrefix    string
+	ProxyEnv        *llb.ProxyEnv
+	SourceDateEpoch time.Time
 }
 
 // GetVariables returns set of variables set for options.

--- a/internal/pkg/pkgfile/build.go
+++ b/internal/pkg/pkgfile/build.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	ctrplatforms "github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
@@ -30,7 +31,8 @@ const (
 	keyTargetPlatform = "platform"
 	keyMultiPlatform  = "multi-platform"
 
-	buildArgPrefix = "build-arg:"
+	buildArgPrefix          = "build-arg:"
+	buildArgSourceDateEpoch = buildArgPrefix + "SOURCE_DATE_EPOCH"
 
 	localNameDockerfile = "dockerfile"
 	sharedKeyHint       = constants.PkgYaml
@@ -44,6 +46,15 @@ func Build(ctx context.Context, c client.Client, options *environment.Options) (
 
 	options.Target = opts[keyTarget]
 	options.ProxyEnv = proxyEnvFromBuildArgs(filter(opts, buildArgPrefix))
+
+	if sourceDateEpoch, ok := opts[buildArgSourceDateEpoch]; ok {
+		timestamp, err := strconv.ParseInt(sourceDateEpoch, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing %q: %w", buildArgSourceDateEpoch, err)
+		}
+
+		options.SourceDateEpoch = time.Unix(timestamp, 0)
+	}
 
 	platforms := []environment.Platform{options.TargetPlatform}
 


### PR DESCRIPTION
In general, buildkit ignores timestamps when caching intermediate build
results, but still timestamps leak into the final container image.

So if the package is rebuilt with cache, output image stays same (even
though build step might produce different timestamps, but same content,
final output will still be cached).

This new feature enforces timestamp from `SOURCE_DATE_EPOCH` on the
output in the `finalize` step so that build is reproducible.

The downside is that if the build step is used in other steps, and
`SOURCE_DATE_EPOCH` is used, it might cause cascading rebuilds.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>